### PR TITLE
feat: Add tests for user login

### DIFF
--- a/test/handin_web/controllers/user_session_controller_test.exs
+++ b/test/handin_web/controllers/user_session_controller_test.exs
@@ -1,0 +1,73 @@
+defmodule HandinWeb.UserSessionControllerTest do
+  use HandinWeb.ConnCase, async: true
+
+  alias Handin.Accounts
+  alias Handin.Factory
+  alias Handin.Repo
+  alias Handin.Accounts.User
+
+  @valid_attrs %{email: "test@example.com", password: "password123"}
+  @invalid_attrs %{email: "invalid_email", password: "foo"}
+
+  defp fixture(:user) do
+    {:ok, user} = Accounts.create_user(@valid_attrs)
+    user
+  end
+
+  setup do
+    Repo.delete_all(User)
+    :ok
+  end
+
+  describe "POST /users/log_in" do
+    test "logs in an existing user with valid credentials", %{conn: conn} do
+      user = Factory.student_factory() |> Repo.insert!()
+      conn = post(conn, Routes.user_session_path(conn, :create), %{"user" => %{"email" => user.email, "password" => "123456"}})
+      assert redirected_to(conn) == Routes.user_module_path(conn, :index)
+      assert get_flash(conn, :info) == "Welcome back!"
+      assert get_session(conn, :user_token)
+      assert conn.assigns.current_user.id == user.id
+    end
+
+    test "does not log in with invalid credentials", %{conn: conn} do
+      user = Factory.student_factory() |> Repo.insert!()
+      conn = post(conn, Routes.user_session_path(conn, :create), %{"user" => %{"email" => user.email, "password" => "wrongpassword"}})
+      assert redirected_to(conn) == Routes.user_session_path(conn, :new)
+      assert get_flash(conn, :error) == "Invalid email or password"
+      assert !get_session(conn, :user_token)
+      assert conn.assigns.current_user == nil
+    end
+
+    test "does not log in with an unregistered email", %{conn: conn} do
+      conn = post(conn, Routes.user_session_path(conn, :create), %{"user" => %{"email" => "nonexistent@example.com", "password" => "anypassword"}})
+      assert redirected_to(conn) == Routes.user_session_path(conn, :new)
+      assert get_flash(conn, :error) == "Invalid email or password"
+      assert !get_session(conn, :user_token)
+      assert conn.assigns.current_user == nil
+    end
+
+    test "logs in an admin user and redirects to admin dashboard", %{conn: conn} do
+      admin = Factory.admin_factory() |> Repo.insert!()
+      conn = post(conn, Routes.user_session_path(conn, :create), %{"user" => %{"email" => admin.email, "password" => "123456"}})
+      assert redirected_to(conn) == Routes.admin_user_path(conn, :index) # Assuming this route is /admin/users
+      assert get_flash(conn, :info) == "Welcome back!"
+      assert get_session(conn, :user_token)
+      assert conn.assigns.current_user.id == admin.id
+    end
+  end
+
+  describe "DELETE /users/log_out" do
+    test "logs out a logged in user", %{conn: conn} do
+      user = fixture(:user)
+      conn = conn |> log_in_user(user) |> delete(Routes.user_session_path(conn, :delete))
+      assert !get_session(conn, :user_token)
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+    end
+
+    test "does not error if no user is logged in", %{conn: conn} do
+      conn = delete(conn, Routes.user_session_path(conn, :delete))
+      assert !get_session(conn, :user_token)
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -17,6 +17,15 @@ defmodule Handin.Factory do
     }
   end
 
+  def admin_factory do
+    %User{
+      hashed_password: Bcrypt.hash_pwd_salt("123456"),
+      email: "admin@example.com",
+      role: :admin,
+      confirmed_at: DateTime.utc_now()
+    }
+  end
+
   def lecturer_factory do
     %User{
       hashed_password: Bcrypt.hash_pwd_salt("123456"),


### PR DESCRIPTION
This commit introduces a test suite for the user login functionality located in `HandinWeb.UserSessionController`.

The following scenarios are covered:
- Successful login for a regular user (student/lecturer).
- Failed login due to an incorrect password.
- Failed login due to an unregistered email address.
- Successful login for an admin user, ensuring redirection to the admin dashboard.

A new factory for creating admin users (`admin_factory`) was added to `test/support/factory.ex` to support the admin login test.

Note: Due to limitations in my execution environment, it was not possible for me to run the Elixir test suite. I generated and verified the tests step-by-step, but could not execute them to confirm they pass.